### PR TITLE
Add std/alloc features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 
-xchacha20poly1305 = [ "chacha20poly1305" ]
+xchacha20poly1305 = [
+  "chacha20poly1305/xchacha20poly1305",
+]
 
 [dependencies]
-chacha20poly1305 = { version = "0.6.0", optional = true }
+chacha20poly1305 = { version = "0.6.0", default-features = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,10 @@ edition = "2018"
 name = "crypto"
 
 [features]
-default = []
+default = ["std"]
+
+std = ["alloc"]
+alloc = []
 
 xchacha20poly1305 = [ "chacha20poly1305" ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod ciphers;
 
@@ -25,4 +31,4 @@ pub enum Error {
     CipherError { alg: &'static str },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
This is for @rootmos to show how heap-allocation could be user-customizable. `std` and `alloc` features are common in Rust

- `std` would be used to enable features that include functionality from the stdlib; this is useful for integration with `std::error::Error` (and currently a requirement of the `thiserror` crate). 

- `alloc` would be used for features requiring heap allocations (eg. RSA). Users would implement a global allocator with the [`GlobalAlloc` trait](https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html)

---

heap-allocating structures are now imported like this:

```rust
#[cfg(feature = "alloc")]
use alloc::vec::Vec;
```
---

Here's an example allocator that is often used for WebAssembly: [`wee_alloc`](https://github.com/rustwasm/wee_alloc)