### PR TITLE
Correct Ed25519-SHA512 nomenclature

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -16,7 +16,7 @@ impl SecretKey {
     pub fn generate() -> crate::Result<Self> {
         let mut bs = [0u8; SECRET_KEY_LENGTH];
         crate::rand::fill(&mut bs)?;
-        Self::from_le_bytes(bs)
+        Ok(Self::from_bytes(bs))
     }
 
     pub fn public_key(&self) -> PublicKey {


### PR DESCRIPTION
https://github.com/ZcashFoundation/ed25519-zebra/blob/0e7a96a267a756e642e102a28a44dd79b9c7df69/src/signing_key.rs#L75