### PR TITLE
Add a rand::gen::<T>() function to fill based on generic sized type

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -8,6 +8,12 @@ pub fn fill(bs: &mut [u8]) -> crate::Result<()> {
     })
 }
 
+pub unsafe fn gen<T>() -> crate::Result<T> {
+    let mut t = core::mem::MaybeUninit::uninit();
+    fill(core::slice::from_raw_parts_mut(t.as_mut_ptr() as *mut u8, core::mem::size_of::<T>()))?;
+    Ok(t.assume_init())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+/// Fill the buffer `bs` with cryptographically strong entropy from the operating systems
+/// recommended entropy source
 pub fn fill(bs: &mut [u8]) -> crate::Result<()> {
     getrandom::getrandom(bs).map_err(|e| crate::Error::SystemError {
         call: "getrandom::getrandom",
@@ -8,9 +10,17 @@ pub fn fill(bs: &mut [u8]) -> crate::Result<()> {
     })
 }
 
+/// Generate a cryptographically strong random value of a `Sized` type `T`
+///
+/// # Safety
+/// This function fills the memory of the returned type with random values, there are no guarantees
+/// that the type's invariants hold and so may lead to undefined behavior if used inappropriately.
 pub unsafe fn gen<T>() -> crate::Result<T> {
     let mut t = core::mem::MaybeUninit::uninit();
-    fill(core::slice::from_raw_parts_mut(t.as_mut_ptr() as *mut u8, core::mem::size_of::<T>()))?;
+    fill(core::slice::from_raw_parts_mut(
+        t.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<T>(),
+    ))?;
     Ok(t.assume_init())
 }
 


### PR DESCRIPTION
Open questions:
- Is this the best/preferred/correct? way to fill an uninitialized byte array?
- How do we want to test this and similar methods? Can we apply some simple tests from the [TestU01 suite](https://en.wikipedia.org/wiki/TestU01)?