### PR TITLE
Add serialization to Slip10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pbkdf = [ "pbkdf2" ]
 bip39 = [ "pbkdf", "hmac", "sha", "pbkdf", "unicode-normalization" ]
 bip39-en = [ "bip39" ]
 bip39-jp = [ "bip39" ]
-slip10 = ["hmac", "sha", "ed25519", "random" ]
+slip10 = ["hmac", "sha", "ed25519", "random", "serde" ]
 
 [dependencies]
 chacha20poly1305 = { version = "0.7.1", optional = true }
@@ -101,6 +101,11 @@ chacha20poly1305 = { version = "0.7.1", optional = true }
   version = "0.9.0"
   optional = true
   default-features = false
+
+  [dependencies.serde]
+  version = "1.0.123"
+  optional = true
+  features = ["derive"]
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/src/slip10.rs
+++ b/src/slip10.rs
@@ -7,6 +7,8 @@ use crate::{ed25519::SecretKey, macs::hmac::HMAC_SHA512};
 
 use core::{convert::TryFrom, default::Default};
 
+use serde::{Deserialize, Serialize};
+
 use alloc::vec::Vec;
 
 // https://github.com/satoshilabs/slips/blob/master/slip-0010.md
@@ -103,7 +105,7 @@ impl TryFrom<&[u8]> for Key {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Segment {
     hardened: bool,
     bs: [u8; 4],
@@ -120,7 +122,7 @@ impl Segment {
     pub const HARDEN_MASK: u32 = 1 << 31;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Chain(Vec<Segment>);
 
 impl Chain {


### PR DESCRIPTION
# Description of change

Added `serde` as a optional dependency for Slip10 to allow the `Chain` type to be serialized and deserialized. This is required for the stronghold communication layer because the `Chain` type is included in some of the messages. This also means that the `Segment` type must be serializable. 

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Code builds as before and as expected. 

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
