### PR TITLE
Add feature labels to generated docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ repository = "https://github.com/iotaledger/crypto.rs"
 [lib]
 name = "crypto"
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = [ ]
 aes-kw = [ "aes-crate" ]

--- a/src/ciphers/mod.rs
+++ b/src/ciphers/mod.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "chacha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
 pub mod chacha;
 
 #[cfg(feature = "aes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aes")))]
 pub mod aes;
 
 #[cfg(feature = "aes-kw")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aes-kw")))]
 pub mod aes_kw;

--- a/src/hashes/mod.rs
+++ b/src/hashes/mod.rs
@@ -13,7 +13,7 @@ pub mod curl_p;
 #[cfg_attr(docsrs, doc(cfg(feature = "sha")))]
 pub mod sha;
 
-#[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
+#[cfg(any(feature = "blake2b", feature = "sha"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "blake2b", feature = "sha"))))]
 #[doc(inline)]
 pub use digest::{Digest, Output};

--- a/src/hashes/mod.rs
+++ b/src/hashes/mod.rs
@@ -2,14 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "blake2b")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blake2b")))]
 pub mod blake2b;
 
 #[cfg(feature = "curl-p")]
+#[cfg_attr(docsrs, doc(cfg(feature = "curl-p")))]
 pub mod curl_p;
 
 #[cfg(feature = "sha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha")))]
 pub mod sha;
 
 #[cfg(feature = "digest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
 #[doc(inline)]
 pub use digest::{Digest, Output};

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -37,9 +37,11 @@ pub mod wordlist {
     }
 
     #[cfg(feature = "bip39-en")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bip39-en")))]
     include!("bip39.en.rs");
 
     #[cfg(feature = "bip39-jp")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bip39-jp")))]
     include!("bip39.jp.rs");
 
     #[derive(Debug, PartialEq)]

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "pbkdf")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pbkdf")))]
 pub mod pbkdf;
 
 #[cfg(feature = "bip39")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
 pub mod bip39;
 
 #[cfg(feature = "slip10")]
+#[cfg_attr(docsrs, doc(cfg(feature = "slip10")))]
 pub mod slip10;
 
 #[cfg(feature = "x25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "x25519")))]
 pub mod x25519;

--- a/src/keys/pbkdf.rs
+++ b/src/keys/pbkdf.rs
@@ -15,6 +15,7 @@ fn assert_iteration_count(alg: &'static str, count: usize) -> crate::Result<()> 
 }
 
 #[cfg(all(feature = "hmac", feature = "sha"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "hmac", feature = "sha"))))]
 pub fn PBKDF2_HMAC_SHA256(password: &[u8], salt: &[u8], count: usize, buffer: &mut [u8]) -> crate::Result<()> {
     assert_iteration_count("PBKDF2-HMAC-SHA256", count).map(|_| {
         pbkdf2::pbkdf2::<hmac_::Hmac<sha2::Sha256>>(password, salt, count as u32, buffer);
@@ -22,6 +23,7 @@ pub fn PBKDF2_HMAC_SHA256(password: &[u8], salt: &[u8], count: usize, buffer: &m
 }
 
 #[cfg(all(feature = "hmac", feature = "sha"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "hmac", feature = "sha"))))]
 pub fn PBKDF2_HMAC_SHA384(password: &[u8], salt: &[u8], count: usize, buffer: &mut [u8]) -> crate::Result<()> {
     assert_iteration_count("PBKDF2-HMAC-SHA384", count).map(|_| {
         pbkdf2::pbkdf2::<hmac_::Hmac<sha2::Sha384>>(password, salt, count as u32, buffer);
@@ -29,6 +31,7 @@ pub fn PBKDF2_HMAC_SHA384(password: &[u8], salt: &[u8], count: usize, buffer: &m
 }
 
 #[cfg(all(feature = "hmac", feature = "sha"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "hmac", feature = "sha"))))]
 pub fn PBKDF2_HMAC_SHA512(password: &[u8], salt: &[u8], count: usize, buffer: &mut [u8]) -> crate::Result<()> {
     assert_iteration_count("PBKDF2-HMAC-SHA512", count).map(|_| {
         pbkdf2::pbkdf2::<hmac_::Hmac<sha2::Sha512>>(password, salt, count as u32, buffer);

--- a/src/keys/x25519.rs
+++ b/src/keys/x25519.rs
@@ -50,6 +50,7 @@ pub struct SecretKey(x25519_dalek::StaticSecret);
 impl SecretKey {
     /// Generate a new random [`SecretKey`].
     #[cfg(feature = "random")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
     pub fn generate() -> crate::Result<Self> {
         let mut bytes: [u8; SECRET_KEY_LEN] = [0; SECRET_KEY_LEN];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 mod macros;

--- a/src/macs/hmac.rs
+++ b/src/macs/hmac.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 #[cfg(feature = "sha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha")))]
 pub fn HMAC_SHA256(data: &[u8], key: &[u8], mac: &mut [u8; 32]) {
     use hmac_::{Mac, NewMac};
     let mut m = hmac_::Hmac::<sha2::Sha256>::new_varkey(key).unwrap();
@@ -12,6 +13,7 @@ pub fn HMAC_SHA256(data: &[u8], key: &[u8], mac: &mut [u8; 32]) {
 }
 
 #[cfg(feature = "sha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha")))]
 pub fn HMAC_SHA384(data: &[u8], key: &[u8], mac: &mut [u8; 48]) {
     use hmac_::{Mac, NewMac};
     let mut m = hmac_::Hmac::<sha2::Sha384>::new_varkey(key).unwrap();
@@ -20,6 +22,7 @@ pub fn HMAC_SHA384(data: &[u8], key: &[u8], mac: &mut [u8; 48]) {
 }
 
 #[cfg(feature = "sha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha")))]
 pub fn HMAC_SHA512(data: &[u8], key: &[u8], mac: &mut [u8; 64]) {
     use hmac_::{Mac, NewMac};
     let mut m = hmac_::Hmac::<sha2::Sha512>::new_varkey(key).unwrap();

--- a/src/macs/mod.rs
+++ b/src/macs/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "hmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hmac")))]
 pub mod hmac;

--- a/src/signatures/ed25519.rs
+++ b/src/signatures/ed25519.rs
@@ -11,6 +11,7 @@ pub struct SecretKey(ed25519_zebra::SigningKey);
 
 impl SecretKey {
     #[cfg(feature = "random")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
     pub fn generate() -> crate::Result<Self> {
         let mut bs = [0u8; SECRET_KEY_LENGTH];
         crate::utils::rand::fill(&mut bs)?;

--- a/src/signatures/mod.rs
+++ b/src/signatures/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 pub mod ed25519;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "random")]
+#[cfg_attr(docsrs, doc(cfg(feature = "random")))]
 pub mod rand;


### PR DESCRIPTION
# Description of change

This adds labels to the generated documentation to show which features enable specific parts of the library.

Build locally with: `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open`

### Example
<img src="https://user-images.githubusercontent.com/5410284/110513868-9c769e00-80fe-11eb-9526-85c1d46cc0fe.png"/>

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Documentation Fix

## How the change has been tested

CI

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
