### PR TITLE
tests: use CurlP::new() instead of CurlP::default()

### DIFF
--- a/tests/curl_p.rs
+++ b/tests/curl_p.rs
@@ -8,7 +8,7 @@ use crypto::hashes::curl_p::CurlP;
 use bee_ternary::{T1B1Buf, T3B1Buf, TritBuf, TryteBuf};
 
 fn digest(input: &str, output: &str) {
-    let mut curl = CurlP::default();
+    let mut curl = CurlP::new();
 
     let input_trit_buf = TryteBuf::try_from_str(input).unwrap().as_trits().encode::<T1B1Buf>();
     let expected_hash = TryteBuf::try_from_str(output).unwrap();
@@ -18,7 +18,7 @@ fn digest(input: &str, output: &str) {
 }
 
 fn digest_into(input: &str, output: &str) {
-    let mut curl = CurlP::default();
+    let mut curl = CurlP::new();
 
     let input_trit_buf = TryteBuf::try_from_str(input).unwrap().as_trits().encode::<T1B1Buf>();
     let expected_hash = TryteBuf::try_from_str(output).unwrap();


### PR DESCRIPTION
# Description of change

`CurlP::new()` was untested but it calls `CurlP::default()` so testing the former actually tests both.
Should increase the coverage of the module to 100%.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
