### PR TITLE
Smooth out cipher API 

### DIFF
--- a/.changes/smooth-cipher-api.md
+++ b/.changes/smooth-cipher-api.md
@@ -23,13 +23,13 @@ decrypt(
     tag
 );
 
-/// Returns the tag associated with the encryption.
 try_encrypt(
     key,
     nonce,
     associated_data,
     plaintext,
-    ciphertext
+    ciphertext,
+    tag
 );
 
 try_decrypt(

--- a/.changes/smooth-cipher-api.md
+++ b/.changes/smooth-cipher-api.md
@@ -1,0 +1,56 @@
+---
+"iota-crypto": patch
+---
+
+Normalization of the parameters for the encryption and decryption functions.
+- Parameter lists are as follows:
+```rust
+encrypt(
+    key,
+    nonce,
+    associated_data,
+    plaintext,
+    ciphertext,
+    tag
+);
+
+decrypt(
+    key,
+    nonce,
+    associated_data,
+    plaintext,
+    ciphertext,
+    tag
+);
+
+/// Returns the tag associated with the encryption.
+try_encrypt(
+    key,
+    nonce,
+    associated_data,
+    plaintext,
+    ciphertext
+);
+
+try_decrypt(
+    key,
+    nonce,
+    associated_data,
+    plaintext,
+    ciphertext,
+    tag
+);
+```
+
+Changed the BufferSize error to include a name in the error message.
+
+```rust
+/// Produces an error message containing the following: 
+/// $name buffer needs $needs bytes, but it only has $has
+
+Error::BufferSize(
+    name,
+    needs,
+    has
+);
+```

--- a/src/ciphers/aes_kw.rs
+++ b/src/ciphers/aes_kw.rs
@@ -57,7 +57,7 @@ where
     /// See [RFC3394](https://tools.ietf.org/html/rfc3394).
     #[allow(non_snake_case)]
     pub fn wrap_key(&self, plaintext: &[u8], ciphertext: &mut [u8]) -> Result<()> {
-        assert_buffer_gte!(ciphertext.len(), plaintext.len() + BLOCK);
+        assert_buffer_gte!(ciphertext.len(), plaintext.len() + BLOCK, "ciphertext");
 
         if plaintext.len() % BLOCK != 0 {
             return Err(Error::CipherError { alg: "AES Key Wrap" });
@@ -120,8 +120,8 @@ where
     /// See [RFC3394](https://tools.ietf.org/html/rfc3394).
     #[allow(non_snake_case)]
     pub fn unwrap_key(&self, ciphertext: &[u8], plaintext: &mut [u8]) -> Result<()> {
-        assert_buffer_gte!(ciphertext.len(), BLOCK);
-        assert_buffer_gte!(plaintext.len(), ciphertext.len() - BLOCK);
+        assert_buffer_gte!(ciphertext.len(), BLOCK, "ciphertext");
+        assert_buffer_gte!(plaintext.len(), ciphertext.len() - BLOCK, "plaintext");
 
         if ciphertext.len() % BLOCK != 0 {
             return Err(Error::CipherError { alg: "AES Key Wrap" });

--- a/src/ciphers/macros.rs
+++ b/src/ciphers/macros.rs
@@ -24,6 +24,7 @@ macro_rules! impl_aead {
 
                 if plaintext.len() > ciphertext.len() {
                     return Err($crate::Error::BufferSize {
+                        name: "ciphertext",
                         needs: plaintext.len(),
                         has: ciphertext.len(),
                     });
@@ -31,8 +32,25 @@ macro_rules! impl_aead {
 
                 if tag.len() != Self::TAG_LENGTH {
                     return Err($crate::Error::BufferSize {
+                        name: "tag",
                         needs: Self::TAG_LENGTH,
                         has: tag.len(),
+                    });
+                }
+
+                if key.len() != Self::KEY_LENGTH {
+                    return Err($crate::Error::BufferSize {
+                        name: "key",
+                        needs: Self::KEY_LENGTH,
+                        has: key.len(),
+                    });
+                }
+
+                if nonce.len() != Self::NONCE_LENGTH {
+                    return Err($crate::Error::BufferSize {
+                        name: "nonce",
+                        needs: Self::NONCE_LENGTH,
+                        has: nonce.len(),
                     });
                 }
 
@@ -51,16 +69,41 @@ macro_rules! impl_aead {
                 key: &$crate::ciphers::traits::Key<Self>,
                 nonce: &$crate::ciphers::traits::Nonce<Self>,
                 associated_data: &[u8],
-                tag: &$crate::ciphers::traits::Tag<Self>,
-                ciphertext: &[u8],
                 plaintext: &mut [u8],
+                ciphertext: &[u8],
+                tag: &$crate::ciphers::traits::Tag<Self>,
             ) -> crate::Result<usize> {
                 use aead::{AeadInPlace, NewAead};
 
                 if ciphertext.len() > plaintext.len() {
                     return Err($crate::Error::BufferSize {
+                        name: "plaintext",
                         needs: ciphertext.len(),
                         has: plaintext.len(),
+                    });
+                }
+
+                if tag.len() != Self::TAG_LENGTH {
+                    return Err($crate::Error::BufferSize {
+                        name: "tag",
+                        needs: Self::TAG_LENGTH,
+                        has: tag.len(),
+                    });
+                }
+
+                if key.len() != Self::KEY_LENGTH {
+                    return Err($crate::Error::BufferSize {
+                        name: "key",
+                        needs: Self::KEY_LENGTH,
+                        has: key.len(),
+                    });
+                }
+
+                if nonce.len() != Self::NONCE_LENGTH {
+                    return Err($crate::Error::BufferSize {
+                        name: "nonce",
+                        needs: Self::NONCE_LENGTH,
+                        has: nonce.len(),
                     });
                 }
 

--- a/src/ciphers/macros.rs
+++ b/src/ciphers/macros.rs
@@ -12,6 +12,8 @@ macro_rules! impl_aead {
 
             const NAME: &'static str = $name;
 
+            /// Warning: type conversions on the tag type can be tricky. instead of `&mut tag.try_into().unwrap()` use
+            /// `(&mut tag).try_into().unwrap()`
             fn encrypt(
                 key: &$crate::ciphers::traits::Key<Self>,
                 nonce: &$crate::ciphers::traits::Nonce<Self>,

--- a/src/ciphers/macros.rs
+++ b/src/ciphers/macros.rs
@@ -30,30 +30,6 @@ macro_rules! impl_aead {
                     });
                 }
 
-                if tag.len() != Self::TAG_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "tag",
-                        needs: Self::TAG_LENGTH,
-                        has: tag.len(),
-                    });
-                }
-
-                if key.len() != Self::KEY_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "key",
-                        needs: Self::KEY_LENGTH,
-                        has: key.len(),
-                    });
-                }
-
-                if nonce.len() != Self::NONCE_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "nonce",
-                        needs: Self::NONCE_LENGTH,
-                        has: nonce.len(),
-                    });
-                }
-
                 ciphertext[..plaintext.len()].copy_from_slice(plaintext);
 
                 let out: $crate::ciphers::traits::Tag<Self> = Self::new(key)
@@ -80,30 +56,6 @@ macro_rules! impl_aead {
                         name: "plaintext",
                         needs: ciphertext.len(),
                         has: plaintext.len(),
-                    });
-                }
-
-                if tag.len() != Self::TAG_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "tag",
-                        needs: Self::TAG_LENGTH,
-                        has: tag.len(),
-                    });
-                }
-
-                if key.len() != Self::KEY_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "key",
-                        needs: Self::KEY_LENGTH,
-                        has: key.len(),
-                    });
-                }
-
-                if nonce.len() != Self::NONCE_LENGTH {
-                    return Err($crate::Error::BufferSize {
-                        name: "nonce",
-                        needs: Self::NONCE_LENGTH,
-                        has: nonce.len(),
                     });
                 }
 

--- a/src/ciphers/traits.rs
+++ b/src/ciphers/traits.rs
@@ -37,7 +37,7 @@ pub type Tag<T> = GenericArray<u8, <T as Aead>::TagLength>;
 ///
 /// let tag: Tag<Aes256Gcm> = Aes256Gcm::try_encrypt(&key, &nonce, associated_data, plaintext, &mut encrypted)?;
 ///
-/// Aes256Gcm::try_decrypt(&key, &nonce, associated_data, &tag, &encrypted, &mut decrypted)?;
+/// Aes256Gcm::try_decrypt(&key, &nonce, associated_data, &mut decrypted, &encrypted, &tag)?;
 ///
 /// assert_eq!(decrypted, plaintext);
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,11 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 #[derive(Debug, PartialEq)]
 pub enum Error {
     /// Buffer Error
-    BufferSize { needs: usize, has: usize },
+    BufferSize {
+        name: &'static str,
+        needs: usize,
+        has: usize,
+    },
     ///  Cipher Error
     CipherError { alg: &'static str },
     /// Convertion Error
@@ -28,7 +32,9 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Error::BufferSize { needs, has } => write!(f, "buffer needs {} bytes, but it only has {}", needs, has),
+            Error::BufferSize { name, needs, has } => {
+                write!(f, "{} buffer needs {} bytes, but it only has {}", name, needs, has)
+            }
             Error::CipherError { alg } => write!(f, "error in algorithm {}", alg),
             Error::ConvertError { from, to } => write!(f, "failed to convert {} to {}", from, to),
             Error::PrivateKeyError => write!(f, "Failed to generate private key."),

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -106,6 +106,7 @@ impl TryFrom<&[u8]> for Key {
     fn try_from(bs: &[u8]) -> Result<Self, Self::Error> {
         if bs.len() != 64 {
             return Err(crate::Error::BufferSize {
+                name: "key",
                 has: bs.len(),
                 needs: 64,
             });

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,9 +4,10 @@
 #![allow(unused_macros)]
 
 macro_rules! assert_buffer {
-    ($has:expr, $needs:expr, $expr:expr) => {{
+    ($has:expr, $needs:expr, $expr:expr, $name:expr) => {{
         if !($expr) {
             return Err($crate::Error::BufferSize {
+                name: $name,
                 needs: $needs,
                 has: $has,
             });
@@ -15,26 +16,26 @@ macro_rules! assert_buffer {
 }
 
 macro_rules! assert_buffer_lte {
-    ($length:expr, $maximum:expr) => {{
-        assert_buffer!($length, $maximum, $length <= $maximum)
+    ($length:expr, $maximum:expr, $name:expr) => {{
+        assert_buffer!($length, $maximum, $length <= $maximum, $name)
     }};
 }
 
 macro_rules! assert_buffer_gte {
-    ($length:expr, $minimum:expr) => {{
-        assert_buffer!($length, $minimum, $length >= $minimum)
+    ($length:expr, $minimum:expr, $name:expr) => {{
+        assert_buffer!($length, $minimum, $length >= $minimum, $name)
     }};
 }
 
 #[cfg(test)]
 mod tests {
     fn test_assert_lte(length: usize, minimum: usize) -> crate::Result<()> {
-        assert_buffer_lte!(length, minimum);
+        assert_buffer_lte!(length, minimum, "buffer");
         Ok(())
     }
 
     fn test_assert_gte(length: usize, maximum: usize) -> crate::Result<()> {
-        assert_buffer_gte!(length, maximum);
+        assert_buffer_gte!(length, maximum, "buffer");
         Ok(())
     }
 

--- a/tests/aead.rs
+++ b/tests/aead.rs
@@ -32,33 +32,33 @@ fn test_aead_one<A: Aead>(tv: &TestVector) -> crypto::Result<()> {
     assert_eq!(&tag[..], &expected_tag[..]);
 
     let mut out = vec![0; ctx.len()];
-    let len = A::try_decrypt(&key, &nonce, &aad, &tag, &ctx, &mut out)?;
+    let len = A::try_decrypt(&key, &nonce, &aad, &mut out, &ctx, &tag)?;
 
     assert_eq!(&out[..len], &ptx[..]);
 
     let mut corrupted_tag = tag.clone();
     utils::corrupt(&mut corrupted_tag);
-    assert!(A::try_decrypt(&key, &nonce, &aad, &corrupted_tag, &ctx, &mut out).is_err());
+    assert!(A::try_decrypt(&key, &nonce, &aad, &mut out, &ctx, &corrupted_tag).is_err());
 
     let mut corrupted_nonce = nonce.clone();
     utils::corrupt(&mut corrupted_nonce);
-    assert!(A::try_decrypt(&key, &corrupted_nonce, &aad, &tag, &ctx, &mut out).is_err());
+    assert!(A::try_decrypt(&key, &corrupted_nonce, &aad, &mut out, &ctx, &tag).is_err());
 
     if aad.is_empty() {
         assert!(A::try_decrypt(
             &key,
             &nonce,
             &utils::fresh::non_empty_bytestring(),
-            &tag,
+            &mut out,
             &ctx,
-            &mut out
+            &tag,
         )
         .is_err());
     } else {
         let mut corrupted_associated_data = aad;
         utils::corrupt(&mut corrupted_associated_data);
-        assert!(A::try_decrypt(&key, &nonce, &corrupted_associated_data, &tag, &ctx, &mut out).is_err());
-        assert!(A::try_decrypt(&key, &nonce, &utils::fresh::bytestring(), &tag, &ctx, &mut out).is_err());
+        assert!(A::try_decrypt(&key, &nonce, &corrupted_associated_data, &mut out, &ctx, &tag).is_err());
+        assert!(A::try_decrypt(&key, &nonce, &utils::fresh::bytestring(), &mut out, &ctx, &tag).is_err());
     }
 
     Ok(())

--- a/tests/aead.rs
+++ b/tests/aead.rs
@@ -21,12 +21,13 @@ fn test_aead_one<A: Aead>(tv: &TestVector) -> crypto::Result<()> {
     let nonce = hex::decode(tv.nonce).unwrap();
     let aad = hex::decode(tv.associated_data).unwrap();
     let ptx = hex::decode(tv.plaintext).unwrap();
+    let mut tag = vec![0u8; A::TAG_LENGTH];
 
     let expected_ctx = hex::decode(tv.ciphertext).unwrap();
     let expected_tag = hex::decode(tv.tag).unwrap();
 
     let mut ctx = vec![0; ptx.len()];
-    let tag = A::try_encrypt(&key, &nonce, &aad, &ptx, &mut ctx)?;
+    A::try_encrypt(&key, &nonce, &aad, &ptx, &mut ctx, &mut tag)?;
 
     assert_eq!(&ctx[..], &expected_ctx[..]);
     assert_eq!(&tag[..], &expected_tag[..]);


### PR DESCRIPTION
# Description of change

These changes include slight modifications to the Cipher API to make it more user friendly and tweaks to the Buffer error type to give more information.  

## Links to any relevant issues

addresses issue #70 

Is a breaking change because the parameter list was reordered for the `decrypt` and `try_decrypt` functions. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

Used the unit tests and some examples to test out the errors. 

## Change checklist


- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
