### PR TITLE
Add early exit flag to coverage script

### DIFF
--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 # Remove stale coverage report
-rm -r coverage
+rm -rf coverage
 mkdir coverage
 
 # Run tests with profiling instrumentation


### PR DESCRIPTION
# Description of change

Added an early exit flag `-e` to the coverage shell script, so that it will fail if there are any errors in its execution before uploading reports to coveralls (test failures, etc). Original issue: iotaledger/crypto.rs#67.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally to ensure script is working as intended.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
