### PR TITLE
Add secp256k1 signatures/key exchange

### DIFF
--- a/.changes/add-secp256k1.md
+++ b/.changes/add-secp256k1.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": minor
+---
+
+Add `Secp256k1` signatures and Diffie-Hellman key exchange.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pbkdf = [ "pbkdf2" ]
 bip39 = [ "pbkdf", "hmac", "sha", "pbkdf", "unicode-normalization" ]
 bip39-en = [ "bip39" ]
 bip39-jp = [ "bip39" ]
+secp256k1 = [ "k256", "signature" ]
 slip10 = [ "hmac", "sha", "ed25519", "random", "serde" ]
 cipher = [ "aead", "generic-array" ]
 
@@ -122,6 +123,17 @@ chacha20poly1305 = { version = "0.7.1", optional = true }
   version = "1.0.123"
   optional = true
   features = [ "derive" ]
+
+  [dependencies.k256]
+  version = "0.7"
+  optional = true
+  default-features = false
+  features = ["ecdh", "ecdsa", "sha256"]
+
+  [dependencies.signature]
+  version = "1.2"
+  optional = true
+  default-features = false
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To be included in this list an implementation must:
 | macs        | HMAC-SHA2-384      | [`hmac`](/src/macs/hmac.rs)         | [rfc][HMAC-RFC]            | `hmac`             | [official][HMAC-TEST]    | ★★★★☆ |
 | macs        | HMAC-SHA2-512      | [`hmac`](/src/macs/hmac.rs)         | [rfc][HMAC-RFC]            | `hmac`             | [official][HMAC-TEST]    | ★★★★☆ |
 | signatures  | Ed25519            | [`ed25519`](/src/signatures/ed25519.rs)        | [rfc (draft)][ED25519-RFC] | `ed25519-zebra`    | extended                 | ★★★★☆ |
+| signatures  | Secp256k1          | [`secp256k1`](/src/signatures/secp256k1rs)     | [spec][SECP256K1-SPEC]     | `k256`             | extended                 | ☆☆☆☆☆ |
 | utility    |  RANDOM                  | [`random`](/src/utils/rand.rs)              |                            | `getrandom`        | math                     | ★★★★★ |
 
 
@@ -143,3 +144,5 @@ Apache 2.0
 [BIP39-TEST]: https://github.com/bip32JP/bip32JP.github.io/blob/master/test_JP_BIP39.json
 
 [SLIP10-RFC]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
+
+[SECP256K1-SPEC]: https://www.secg.org/sec2-v2.pdf

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,9 +14,11 @@ pub enum Error {
         needs: usize,
         has: usize,
     },
-    ///  Cipher Error
+    /// Cipher Error
     CipherError { alg: &'static str },
-    /// Convertion Error
+    /// Signature Error
+    SignatureError { alg: &'static str },
+    /// Conversion Error
     ConvertError { from: &'static str, to: &'static str },
     /// Private Key Error
     PrivateKeyError,
@@ -36,6 +38,7 @@ impl Display for Error {
                 write!(f, "{} buffer needs {} bytes, but it only has {}", name, needs, has)
             }
             Error::CipherError { alg } => write!(f, "error in algorithm {}", alg),
+            Error::SignatureError { alg } => write!(f, "error in signature algorithm {}", alg),
             Error::ConvertError { from, to } => write!(f, "failed to convert {} to {}", from, to),
             Error::PrivateKeyError => write!(f, "Failed to generate private key."),
             Error::InvalidArgumentError { alg, expected } => write!(f, "{} expects {}", alg, expected),

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -170,8 +170,8 @@ impl AsRef<Chain> for Chain {
     }
 }
 
-impl Into<Vec<u8>> for Key {
-    fn into(self) -> Vec<u8> {
-        self.0.to_vec()
+impl From<Key> for Vec<u8> {
+    fn from(other: Key) -> Self {
+        other.0.to_vec()
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,6 +15,12 @@ macro_rules! assert_buffer {
     }};
 }
 
+macro_rules! assert_buffer_eq {
+    ($length:expr, $target:expr, $name:expr) => {{
+        assert_buffer!($length, $target, $length == $target, $name)
+    }};
+}
+
 macro_rules! assert_buffer_lte {
     ($length:expr, $maximum:expr, $name:expr) => {{
         assert_buffer!($length, $maximum, $length <= $maximum, $name)
@@ -29,6 +35,11 @@ macro_rules! assert_buffer_gte {
 
 #[cfg(test)]
 mod tests {
+    fn test_assert_eq(length: usize, target: usize) -> crate::Result<()> {
+        assert_buffer_eq!(length, target, "buffer");
+        Ok(())
+    }
+
     fn test_assert_lte(length: usize, minimum: usize) -> crate::Result<()> {
         assert_buffer_lte!(length, minimum, "buffer");
         Ok(())
@@ -37,6 +48,15 @@ mod tests {
     fn test_assert_gte(length: usize, maximum: usize) -> crate::Result<()> {
         assert_buffer_gte!(length, maximum, "buffer");
         Ok(())
+    }
+
+    #[test]
+    fn test_assert_buffer_eq() {
+        assert!(test_assert_eq(0, 16).is_err());
+        assert!(test_assert_eq(15, 16).is_err());
+        assert!(test_assert_eq(16, 16).is_ok());
+        assert!(test_assert_eq(17, 16).is_err());
+        assert!(test_assert_eq(255, 16).is_err());
     }
 
     #[test]

--- a/src/signatures/mod.rs
+++ b/src/signatures/mod.rs
@@ -4,3 +4,7 @@
 #[cfg(feature = "ed25519")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 pub mod ed25519;
+
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+pub mod secp256k1;

--- a/src/signatures/secp256k1.rs
+++ b/src/signatures/secp256k1.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::TryInto;
+use k256::elliptic_curve::{
+    ecdh,
+    sec1::{Coordinates, EncodedPoint, ToEncodedPoint},
+};
+use signature::{Error as SigError, Signer, Verifier};
+
+pub type FieldBytes = k256::FieldBytes;
+pub type SharedSecret = k256::ecdh::SharedSecret;
+
+/// Secp256k1 Public Key
+pub struct PublicKey(k256::PublicKey);
+
+impl PublicKey {
+    /// Create a new `PublicKey` from SEC1-encoded bytes.
+    pub fn from_sec1_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        k256::PublicKey::from_sec1_bytes(bytes)
+            .map(Self)
+            .map_err(|_| crate::Error::ConvertError {
+                from: "SEC1 bytes",
+                to: "Secp256k1 Public Key",
+            })
+    }
+
+    pub fn from_coord(x: &[u8], y: &[u8]) -> crate::Result<Self> {
+        let x: &FieldBytes = x.try_into().map_err(|_| crate::Error::ConvertError {
+            from: "bytes",
+            to: "Secp256k1 Point (x)",
+        })?;
+
+        let y: &FieldBytes = y.try_into().map_err(|_| crate::Error::ConvertError {
+            from: "bytes",
+            to: "Secp256k1 Point (y)",
+        })?;
+
+        EncodedPoint::from_affine_coordinates(x, y, false)
+            .try_into()
+            .map(Self)
+            .map_err(|_| crate::Error::ConvertError {
+                from: "Coordinates",
+                to: "Secp256k1 Public Key",
+            })
+    }
+
+    pub fn to_coord(&self) -> crate::Result<(FieldBytes, FieldBytes)> {
+        match self.0.to_encoded_point(false).coordinates() {
+            Coordinates::Uncompressed { x, y } => Ok((*x, *y)),
+            Coordinates::Identity | Coordinates::Compressed { .. } => Err(crate::Error::ConvertError {
+                from: "Secp256k1 Public Key",
+                to: "Coordinates",
+            }),
+        }
+    }
+
+    pub fn verify(&self, message: &[u8], signature: &[u8]) -> crate::Result<()> {
+        signature::Signature::from_bytes(signature)
+            .and_then(|signature| Verifier::verify(self, message, &signature))
+            .map_err(|_| crate::Error::SignatureError { alg: "Secp256k1" })
+    }
+}
+
+impl Verifier<Signature> for PublicKey {
+    fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), SigError> {
+        k256::ecdsa::VerifyingKey::from(self.0.as_affine()).verify(message, &signature.0)
+    }
+}
+
+/// Secp256k1 Secret Key
+pub struct SecretKey(k256::SecretKey);
+
+impl SecretKey {
+    /// Generate a new random `SecretKey`.
+    #[cfg(feature = "random")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
+    pub fn generate() -> crate::Result<Self> {
+        let mut bytes: FieldBytes = Default::default();
+
+        crate::utils::rand::fill(&mut bytes[..])?;
+
+        Self::from_bytes(&bytes[..])
+    }
+
+    /// Create a new `SecretKey` from big-endian bytes.
+    pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        k256::SecretKey::from_bytes(bytes)
+            .map(Self)
+            .map_err(|_| crate::Error::ConvertError {
+                from: "bytes",
+                to: "Secp256k1 Secret Key",
+            })
+    }
+
+    /// Returns the `SecretKey` as a slice of bytes.
+    pub fn to_bytes(&self) -> FieldBytes {
+        self.0.to_bytes()
+    }
+
+    /// Returns the `PublicKey` which corresponds to this `SecretKey`.
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.public_key())
+    }
+
+    pub fn sign(&self, message: &[u8]) -> crate::Result<Signature> {
+        self.try_sign(message)
+            .map_err(|_| crate::Error::SignatureError { alg: "Secp256k1" })
+    }
+
+    /// Computes a Diffie-Hellman `SharedSecret` with the given `PublicKey`.
+    pub fn diffie_hellman(&self, public: &PublicKey) -> SharedSecret {
+        ecdh::diffie_hellman(self.0.secret_scalar(), public.0.as_affine())
+    }
+}
+
+impl Signer<Signature> for SecretKey {
+    fn try_sign(&self, message: &[u8]) -> Result<Signature, SigError> {
+        k256::ecdsa::SigningKey::from(&self.0).try_sign(message).map(Signature)
+    }
+}
+
+/// Secp256k1 Signature (fixed-size)
+#[derive(Debug)]
+pub struct Signature(k256::ecdsa::Signature);
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl signature::Signature for Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, SigError> {
+        k256::ecdsa::Signature::from_bytes(bytes).map(Self)
+    }
+}

--- a/tests/secp256k1.rs
+++ b/tests/secp256k1.rs
@@ -1,0 +1,44 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "secp256k1")]
+
+use crypto::signatures::secp256k1::{PublicKey, SecretKey};
+
+mod utils;
+
+#[test]
+fn test_secp256k1_sign_verify() {
+    let skb = hex::decode("ea68a753b20281db2cd5084a215fdda70c7e3cf3d167575fce9b02eb1f36fe9c").unwrap();
+    let sk = SecretKey::from_bytes(&skb).unwrap();
+
+    let pkb = hex::decode("af81cf426b23df0f01c2f6acd86a7fa24cf48c1637c320e06f40dc315b597f6d6c6ccd209dfd4ea7ddb20c22b778c73dfbd44c2f7eeebed224878009fda33d16").unwrap();
+    let pk = PublicKey::from_bytes(&pkb).unwrap();
+
+    assert_eq!(pk.to_bytes(), sk.public_key().to_bytes());
+
+    let msg = utils::fresh::bytestring();
+    let mut sig = sk.sign(&msg).unwrap().as_ref().to_vec();
+
+    assert!(pk.verify(&msg, &sig).is_ok());
+    assert!(SecretKey::generate().unwrap().public_key().verify(&msg, &sig).is_err());
+
+    utils::corrupt(&mut sig);
+    assert!(pk.verify(&msg, &sig).is_err());
+}
+
+#[cfg(feature = "random")]
+#[test]
+fn test_secp256k1_sign_verify_random() {
+    let sk = SecretKey::generate().unwrap();
+    let pk = sk.public_key();
+
+    let msg = utils::fresh::bytestring();
+    let mut sig = sk.sign(&msg).unwrap().as_ref().to_vec();
+
+    assert!(pk.verify(&msg, &sig).is_ok());
+    assert!(SecretKey::generate().unwrap().public_key().verify(&msg, &sig).is_err());
+
+    utils::corrupt(&mut sig);
+    assert!(pk.verify(&msg, &sig).is_err());
+}


### PR DESCRIPTION
# Description of change

Adds secp256k1 signatures and key exchange to use with JSON web tokens.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested through identity.rs

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
