### PR TITLE
Enable segment field access

### DIFF
--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -145,15 +145,12 @@ pub mod wordlist {
                 None => return Err(Error::NoSuchWord(w.to_string())),
                 Some(idx) => {
                     let r = i % 8;
+                    acc <<= 8 - r;
+                    acc |= idx >> (11 - (8 - r));
+                    data.push(acc as u8);
                     if r + 11 < 16 {
-                        acc <<= 8 - r;
-                        acc |= idx >> (11 - (8 - r));
-                        data.push(acc as u8);
                         acc = idx & ((1 << (11 - (8 - r))) - 1);
                     } else {
-                        acc <<= 8 - r;
-                        acc |= idx >> (11 - (8 - r));
-                        data.push(acc as u8);
                         acc = (idx & ((1 << (11 - (8 - r))) - 1)) >> (11 - 8 - (8 - r));
                         data.push(acc as u8);
                         acc = idx & ((1 << (11 - 8 - (8 - r))) - 1);

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -133,6 +133,12 @@ impl Segment {
             bs: i.to_be_bytes(), // ser32(i)
         }
     }
+    pub fn hardened(&self) -> bool {
+        self.hardened
+    }
+    pub fn bs(&self) -> [u8; 4] {
+        self.bs
+    }
 
     pub const HARDEN_MASK: u32 = 1 << 31;
 }


### PR DESCRIPTION
# Description of change

Enable `Segment` field access to enable python binding for iota.rs usage.

## Type of change

- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Compiled and tested pass.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
