### PR TITLE
fix(ci): run all tests, not just for coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,4 +74,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --manifest-path=Cargo.toml --all --release --all-features
+        args: --manifest-path=Cargo.toml --lib --all --release --all-features --tests

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you have questions about how to use this library, or why certain decisions we
 ## Tests
 
 ```
-cargo test --lib --all-features
+cargo test --lib --all --all-features --tests
 ```
 ### Doctest
 We aim to supply at least one docstest for every interface, so to see real world usage consult the rustdocs.


### PR DESCRIPTION
This just updates the test runner in the action to actually run all the tests. Previously we were only doing this for our coverage.