### PR TITLE
Enable to access the segments in Chain structure

### DIFF
--- a/.changes/chain_access.md
+++ b/.changes/chain_access.md
@@ -1,0 +1,6 @@
+---
+"iota-crypto": minor
+---
+
+* Enabled to access the `Segment` vector in `Chain`.
+* Added consistent line breaks between methods.

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -133,9 +133,11 @@ impl Segment {
             bs: i.to_be_bytes(), // ser32(i)
         }
     }
+
     pub fn hardened(&self) -> bool {
         self.hardened
     }
+
     pub fn bs(&self) -> [u8; 4] {
         self.bs
     }

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -164,6 +164,10 @@ impl Chain {
         ss.extend_from_slice(&o.as_ref().0);
         Self(ss)
     }
+
+    pub fn segments(&self) -> Vec<Segment> {
+        self.0.clone()
+    }
 }
 
 impl Default for Chain {


### PR DESCRIPTION
# Description of change

- Enable to access the `Vec<Segment>` in `Chain` for python binding.
- Added consistent line breaks between methods.

## Type of change

- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Compiled and tested pass.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
