### PR TITLE
Cosmetics - use of standard traits over specialized implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## \[0.9.2]
+- Add standard trait implementation of`From` for Slip10 `Seed`. Deprecates `Seed::from_bytes()`.
+- Use of standard trait `Default` for Slip10 `Chain` deprecates `Chain::empty()`.
+
 ## \[0.9.1]
 
 - Make `iota-crypto` `no_std`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-crypto"
-version = "0.9.1"
+version = "0.9.2"
 license = "Apache-2.0"
 authors = [
   "Gustav Behm <gustav.behm@iota.org>",

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -163,7 +163,7 @@ pub struct Chain(Vec<Segment>);
 
 impl Chain {
     pub fn empty() -> Self {
-        Self(Vec::new())
+        Self(Vec::default())
     }
 
     pub fn from_u32<I: IntoIterator<Item = u32>>(is: I) -> Self {

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -5,7 +5,10 @@
 
 use crate::{macs::hmac::HMAC_SHA512, signatures::ed25519::SecretKey};
 
-use std::convert::{From, TryFrom};
+use core::{
+    convert::{From, TryFrom},
+    default::Default,
+};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -162,6 +162,7 @@ impl Segment {
 pub struct Chain(Vec<Segment>);
 
 impl Chain {
+    #[deprecated(since = "0.9.2", note = "Use `Chain::default()` instead.`")]
     pub fn empty() -> Self {
         Self(Vec::default())
     }

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -36,6 +36,7 @@ impl Curve {
 ///
 /// But since the seed entropy is always passed through HMAC-SHA512 any bytesequence is acceptable,
 /// therefore formally the size requirement is context sensitive.
+#[derive(Default)]
 pub struct Seed(Vec<u8>);
 
 impl Seed {
@@ -117,7 +118,7 @@ impl TryFrom<&[u8]> for Key {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Segment {
     hardened: bool,
     bs: [u8; 4],
@@ -142,7 +143,7 @@ impl Segment {
     pub const HARDEN_MASK: u32 = 1 << 31;
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Chain(Vec<Segment>);
 
 impl Chain {
@@ -166,12 +167,6 @@ impl Chain {
 
     pub fn segments(&self) -> Vec<Segment> {
         self.0.clone()
-    }
-}
-
-impl Default for Chain {
-    fn default() -> Self {
-        Chain::empty()
     }
 }
 

--- a/tests/fixtures/slip10_ed25519.rs
+++ b/tests/fixtures/slip10_ed25519.rs
@@ -6,7 +6,7 @@
         master_private_key: "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7",
         chains: vec![
             TestChain {
-                chain: Chain::empty(),
+                chain: Chain::default(),
                 chain_code: "90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb",
                 private_key: "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7",
             },
@@ -49,7 +49,7 @@
         master_private_key: "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012",
         chains: vec![
             TestChain {
-                chain: Chain::empty(),
+                chain: Chain::default(),
                 chain_code: "ef70a74db9c3a5af931b5fe73ed8e1a53464133654fd55e7a66f8570b8e33c3b",
                 private_key: "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012",
             },

--- a/tests/slip10.rs
+++ b/tests/slip10.rs
@@ -26,7 +26,7 @@ mod test {
         let tvs = include!("fixtures/slip10_ed25519.rs");
 
         for tv in &tvs {
-            let seed = Seed::from_bytes(&hex::decode(tv.seed).unwrap());
+            let seed: Seed = hex::decode(tv.seed).unwrap().into();
 
             let m = seed.to_master_key(Curve::Ed25519);
             let mut expected_master_chain_code = [0u8; 32];


### PR DESCRIPTION
The changes in this PR are almost all cosmetics and for "rust"-ier feelings.
Biggest change is the standard trait `From` implementation for the Seed which removes the formerly hard constraints on Seed-creation.

## Type of change

- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

As almost everything is cosmetics, only a small test has been added to prove that the generated Seed via `From` is the same as the formerly used `from_bytes()`.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
