### PR TITLE
Bump `bee-ternary` to `v0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ aead = { version = "0.4", optional = true, default-features = false }
 aes-crate = { version = "0.7", optional = true, default-features = false, package = "aes" }
 aes-gcm = { version = "0.9", optional = true, default-features = false, features = [ "aes" ] }
 bee-common-derive = { version = "0.1.1-alpha", optional = true, default-features = false }
-bee-ternary = { version = "0.5.2", optional = true, default-features = false }
+bee-ternary = { version = "0.6.0", optional = true, default-features = false }
 blake2 = { version = "0.9", optional = true, default-features = false }
 byteorder = { version = "1.4", optional = true, default-features = false }
 chacha20poly1305 = { version = "0.8", optional = true }


### PR DESCRIPTION
This is blocking `bee-message` and Chronicle. This PR itself is currently blocked by #130.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
