### PR TITLE
Make `ed25519`, `blake2b` and `curl-p` features `no_std` compatible.

### DIFF
--- a/.changes/no-std-curlp-blake2b-ed25519
+++ b/.changes/no-std-curlp-blake2b-ed25519
@@ -1,0 +1,5 @@
+---
+"iota-crypto": minor
+---
+
+Make `ed25519`, `blake2b` and `curl-p` features `no_std` compatible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ zeroize = { version = "1.3", optional = true, default-features = false }
 
 [dev-dependencies]
 hex = { version = "0.4", default-features = false, features = [ "alloc" ]}
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", default-features = false, features = [ "std", "std_rng" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ blake2 = { version = "0.9", optional = true, default-features = false }
 byteorder = { version = "1.4", optional = true, default-features = false }
 chacha20poly1305 = { version = "0.8", optional = true }
 digest = { version = "0.9", optional = true, default-features = false }
-ed25519-zebra = { version = "2.2", optional = true, default-features = false }
+ed25519-zebra = { version = "3.0", optional = true, default-features = false }
 generic-array = { version = "0.14", optional = true, default-features = false }
 getrandom = { version = "0.2", optional = true, default-features = false, features = [ "js" ] }
 hmac_ = { version = "0.11", optional = true, default-features = false, package = "hmac" }
@@ -99,8 +99,8 @@ x25519-dalek = { version = "1.1", optional = true, default-features = false, fea
 zeroize = { version = "1.3", optional = true, default-features = false }
 
 [dev-dependencies]
-hex = "0.4"
-rand = "0.8"
+hex = { version = "0.4", default-features = false, features = [ "alloc" ]}
+rand = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ random = [ "getrandom" ]
 aes = [ "aes-cbc", "aes-gcm", "aes-kw" ]
 blake2b = [ "blake2", "digest" ]
 ternary_hashes = [ ]
-curl-p = [ "ternary_hashes", "bee-ternary", "lazy_static/spin_no_std" ]
+curl-p = [ "ternary_hashes", "bee-ternary" ]
 kerl_deprecated_do_not_use = [
   "ternary_hashes",
   "bee-ternary",


### PR DESCRIPTION
Blocked by https://github.com/iotaledger/crypto.rs/pull/109