### PR TITLE
Impl missing `FixedOutputReset` for `Blake2b256` and `Blake2b160`

### DIFF
--- a/.changes/blake2b256-fixed-output-reset-impl.md
+++ b/.changes/blake2b256-fixed-output-reset-impl.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": patch
+---
+
+Impl missing `FixedOutputReset` for `Blake2b256` and `Blake2b160`.

--- a/src/hashes/blake2b.rs
+++ b/src/hashes/blake2b.rs
@@ -4,7 +4,7 @@
 use blake2::Blake2b;
 use digest::{
     generic_array::typenum::{U20, U32},
-    FixedOutput, HashMarker, Output, OutputSizeUser, Reset, Update,
+    FixedOutput, FixedOutputReset, HashMarker, Output, OutputSizeUser, Reset, Update,
 };
 
 // blake2 has [`Blake2s256`] instance but not for 160 bits.
@@ -29,15 +29,21 @@ impl OutputSizeUser for Blake2b256 {
     type OutputSize = U32;
 }
 
+impl Reset for Blake2b256 {
+    fn reset(&mut self) {
+        self.0.reset();
+    }
+}
+
 impl FixedOutput for Blake2b256 {
     fn finalize_into(self, out: &mut Output<Self>) {
         self.0.finalize_into(out);
     }
 }
 
-impl Reset for Blake2b256 {
-    fn reset(&mut self) {
-        self.0.reset();
+impl FixedOutputReset for Blake2b256 {
+    fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
+        self.0.finalize_into_reset(out);
     }
 }
 
@@ -70,15 +76,21 @@ impl OutputSizeUser for Blake2b160 {
     type OutputSize = U20;
 }
 
+impl Reset for Blake2b160 {
+    fn reset(&mut self) {
+        self.0.reset();
+    }
+}
+
 impl FixedOutput for Blake2b160 {
     fn finalize_into(self, out: &mut Output<Self>) {
         self.0.finalize_into(out);
     }
 }
 
-impl Reset for Blake2b160 {
-    fn reset(&mut self) {
-        self.0.reset();
+impl FixedOutputReset for Blake2b160 {
+    fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
+        self.0.finalize_into_reset(out);
     }
 }
 


### PR DESCRIPTION
With `digest` v0.10.0, `Digest::finalize_reset` is now automatically implemented depending on a bound that wasn't implemented by crypto.rs so the method disappeared and broke dependent crates.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
