### PR TITLE
Fix ternary encoding b1t6 on `no_std` compilations

### DIFF
--- a/.changes/fix-b1t6-no-std.md
+++ b/.changes/fix-b1t6-no-std.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": patch
+---
+
+Fix ternary encoding b1t6 on `no_std` compilations.

--- a/src/encoding/ternary/b1t6.rs
+++ b/src/encoding/ternary/b1t6.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use crate::encoding::ternary::{Btrit, RawEncoding, RawEncodingBuf, TritBuf, Trits, Tryte};
 


### PR DESCRIPTION
## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
