### PR TITLE
Allow `no_std` serde

### DIFF
--- a/.changes/serde-no-std
+++ b/.changes/serde-no-std
@@ -1,0 +1,5 @@
+---
+"iota-crypto": minor
+---
+
+Make `serde` dependency `no_std` compatible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ description = "The canonical source of cryptographic ground-truth for all IOTA R
 homepage = "https://iota.org"
 repository = "https://github.com/iotaledger/crypto.rs"
 exclude = [ "/tests", "/.github", "/.changes" ]
+# This resolver prevents breaking no_std with dev-dependencies
+# See https://rust-lang.github.io/rfcs/2957-cargo-features2.html
+resolver = "2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -21,7 +24,7 @@ name = "crypto"
 
 [features]
 default = [ ]
-std = [ ]
+std = [ "serde?/std" ]
 aes-cbc = [
   "dep:aes",
   "cipher",
@@ -100,7 +103,7 @@ pbkdf2 = { version = "0.12", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 subtle = { version = "2.4", default-features = false, optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, features = [ "derive" ] }
+serde = { version = "1.0", optional = true, default-features = false, features = [ "derive" ] }
 sha3 = { version = "0.10", optional = true, default-features = false }
 tiny-keccak = { version = "2.0", optional = true, default-features = false, features = [ "keccak" ] }
 unicode-normalization = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION
# Description of change

The `serde` dependency used default features, which includes `std`, thus breaking no_std. 

Additionally, the `[dev-dependencies]` also cause the build to fail on `no_std` targets. A new resolver is added to resolve this.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Build using

```sh
cargo build  --target riscv64gc-unknown-none-elf
```

with various feature combinations. Note that the `random` feature will not build on some targets, including the above.
