### PR TITLE
Fix `no_std` serde

### DIFF
--- a/.changes/no-std-serde.md
+++ b/.changes/no-std-serde.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": patch
+---
+
+Use `alloc` serde feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "iota-crypto"
 version = "0.19.0"
 license = "Apache-2.0"
 authors = [ "IOTA Stiftung" ]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 keywords = [ "iota", "cryptography", "security" ]
 categories = [ "security" ]
@@ -11,7 +11,6 @@ description = "The canonical source of cryptographic ground-truth for all IOTA R
 homepage = "https://iota.org"
 repository = "https://github.com/iotaledger/crypto.rs"
 exclude = [ "/tests", "/.github", "/.changes" ]
-resolver = "2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -110,7 +109,7 @@ pbkdf2 = { version = "0.12", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 subtle = { version = "2.4", default-features = false, optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false, features = [ "derive" ] }
+serde = { version = "1.0", optional = true, default-features = false, features = [ "derive", "alloc" ] }
 sha3 = { version = "0.10", optional = true, default-features = false }
 tiny-keccak = { version = "2.0", optional = true, default-features = false, features = [ "keccak" ] }
 unicode-normalization = { version = "0.1", optional = true, default-features = false }

--- a/src/keys/age.rs
+++ b/src/keys/age.rs
@@ -810,7 +810,6 @@ mod tests {
 
     #[cfg(feature = "std")]
     fn enc_crate(plaintext: &[u8]) -> Vec<u8> {
-        use core::convert::TryInto;
         let password = "password".as_bytes();
         let work_factor = 1_u8.try_into().unwrap();
         let salt = [0x11_u8; 16];

--- a/src/keys/slip10.rs
+++ b/src/keys/slip10.rs
@@ -428,7 +428,6 @@ impl KeyImpl {
 
                 if let Ok(sk_delta) = k256::SecretKey::from_bytes(self.secret_bytes().into()) {
                     if parent_key[0] == 0 {
-                        use core::convert::TryInto;
                         let sk = k256::SecretKey::from_bytes((&parent_key[1..]).try_into().unwrap())
                             .expect("valid Secp256k1 parent secret key");
 


### PR DESCRIPTION
# Description of change

The serde dependency cannot use alloc types without the feature, so this adds that feature. I also updated the rust edition while I was changing the cargo file.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)