### PR TITLE
fix: use separator from `WordList` when decoding

### DIFF
--- a/.changes/bip39-decode-separator.md
+++ b/.changes/bip39-decode-separator.md
@@ -1,5 +1,5 @@
 ---
-"iota-crypto": minor
+"iota-crypto": patch
 ---
 
 Use word separator provided in `WordList` when decoding. Disallow tolaration for multiple whitespaces when single whitespace is defined as a word-separator.

--- a/.changes/bip39-decode-separator.md
+++ b/.changes/bip39-decode-separator.md
@@ -2,4 +2,4 @@
 "iota-crypto": patch
 ---
 
-Use word separator provided in `WordList` when decoding. Disallow tolaration for multiple whitespaces when single whitespace is defined as a word-separator.
+Use word separator provided in `WordList` when decoding. Disallow toleration for multiple whitespace when single whitespace is defined as a word separator.

--- a/.changes/bip39-decode-separator.md
+++ b/.changes/bip39-decode-separator.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": minor
+---
+
+Use word separator provided in `WordList` when decoding. Disallow tolaration for multiple whitespaces when single whitespace is defined as a word-separator.

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -139,7 +139,9 @@ pub mod wordlist {
         let mut acc = 0;
         let mut i = 0;
         let ms = ms.chars().nfkd().collect::<String>();
-        for ref w in ms.split_whitespace() {
+        let separator = wordlist.separator.chars().nfkd().collect::<String>();
+
+        for ref w in ms.split(&separator) {
             match wordlist.words.iter().position(|v| v == w) {
                 None => return Err(Error::NoSuchWord(w.to_string())),
                 Some(idx) => {

--- a/tests/bip39.rs
+++ b/tests/bip39.rs
@@ -66,6 +66,47 @@ fn test_wordlist_codec() {
     }
 }
 
+#[test]
+fn test_mnemonic_phrase_when_separator_is_repeated() {
+    let test_cases = &[
+        // U+3000 separator
+        ("　", true),
+        // whitespace(U+0020) is also allowed as a separator, because U+3000 is normalized to the whitespace
+        (" 　", false),
+        (" ", true),
+        ("  ", false),
+        ("　 ", false),
+        ("　 　", false),
+    ];
+
+    for case in test_cases {
+        let mnemonic_phrase = format!("あいこくしん{}あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あおぞら", case.0);
+        if case.1 {
+            assert!(
+                wordlist::decode(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
+                "{}",
+                mnemonic_phrase
+            );
+            assert!(
+                wordlist::verify(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
+                "{}",
+                mnemonic_phrase
+            );
+        } else {
+            assert!(
+                wordlist::decode(&mnemonic_phrase, &wordlist::JAPANESE).is_err(),
+                "{}",
+                mnemonic_phrase
+            );
+            assert!(
+                wordlist::verify(&mnemonic_phrase, &wordlist::JAPANESE).is_err(),
+                "{}",
+                mnemonic_phrase
+            );
+        }
+    }
+}
+
 // #[test]
 // fn test_wordlist_codec_different_data_different_encodings() {
 // for _ in 0..1000 {

--- a/tests/bip39.rs
+++ b/tests/bip39.rs
@@ -72,8 +72,8 @@ fn test_mnemonic_phrase_when_separator_is_repeated() {
         // U+3000 separator
         ("　", true),
         // whitespace(U+0020) is also allowed as a separator, because U+3000 is normalized to the whitespace
-        (" 　", false),
         (" ", true),
+        (" 　", false),
         ("  ", false),
         ("　 ", false),
         ("　 　", false),
@@ -81,29 +81,18 @@ fn test_mnemonic_phrase_when_separator_is_repeated() {
 
     for case in test_cases {
         let mnemonic_phrase = format!("あいこくしん{}あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あおぞら", case.0);
-        if case.1 {
-            assert!(
-                wordlist::decode(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
-                "{}",
-                mnemonic_phrase
-            );
-            assert!(
-                wordlist::verify(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
-                "{}",
-                mnemonic_phrase
-            );
-        } else {
-            assert!(
-                wordlist::decode(&mnemonic_phrase, &wordlist::JAPANESE).is_err(),
-                "{}",
-                mnemonic_phrase
-            );
-            assert!(
-                wordlist::verify(&mnemonic_phrase, &wordlist::JAPANESE).is_err(),
-                "{}",
-                mnemonic_phrase
-            );
-        }
+        assert_eq!(
+            wordlist::decode(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
+            case.1,
+            "{}",
+            mnemonic_phrase
+        );
+        assert_eq!(
+            wordlist::verify(&mnemonic_phrase, &wordlist::JAPANESE).is_ok(),
+            case.1,
+            "{}",
+            mnemonic_phrase
+        );
     }
 }
 

--- a/tests/bip39.rs
+++ b/tests/bip39.rs
@@ -96,6 +96,22 @@ fn test_mnemonic_phrase_when_separator_is_repeated() {
     }
 }
 
+#[test]
+fn test_mnemonic_phrase_additional_whitespace() {
+    // additional whitespace at the beginning
+    assert!(
+        wordlist::decode(" sand luggage rack used middle crater deal scare high ring swim fish use then video visa can foot clog base quality all elephant retreat", &wordlist::ENGLISH).is_err(),
+    );
+    // additional whitespace in between
+    assert!(
+        wordlist::decode("sand  luggage rack used middle crater deal scare high ring swim fish use then video visa can foot clog base quality all elephant retreat", &wordlist::ENGLISH).is_err(),
+    );
+    // additional whitespace at the end
+    assert!(
+        wordlist::decode("sand luggage rack used middle crater deal scare high ring swim fish use then video visa can foot clog base quality all elephant retreat ", &wordlist::ENGLISH).is_err(),
+    );
+}
+
 // #[test]
 // fn test_wordlist_codec_different_data_different_encodings() {
 // for _ in 0..1000 {


### PR DESCRIPTION
# Description of change

the BIP39 implementation uses `WordList` as a source for mnemonics: https://github.com/iotaledger/crypto.rs/blob/9d155ec7b2d8a239d2bf4dae658aadc83e1b69e4/src/keys/bip39.rs#L33 `WordList` also defines the word separator. When `encode()` the given separator is used to generate the mnemonic phrase. When `decode()` the `split_whitespace()` is used which makes the decoding fail for non-whitespace separators.

Additionally, `split_whitespace()` allows repetition of the separator (`\s+`), which causes two side-effects:
 -  when double space is used `verify()` passes, but produced seed is different from the phrase with one space
 -  edge case: when the word starts with a separator character, the `decode()` would fail 


## Links to any relevant issues

This  PR also closes  #125  and fixes https://github.com/iotaledger/iota-sdk/issues/421

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix



## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
