### PR TITLE
Fix coverage check

### DIFF
--- a/.changes/bump-dependency-version-to-fix-vulnerability.md
+++ b/.changes/bump-dependency-version-to-fix-vulnerability.md
@@ -1,0 +1,5 @@
+---
+"iota-crypto": patch
+---
+
+Bump dependencies to fix vulnerability from `cargo audit` (`curve25519-dalek`: 3.2 -> 4.1.3, `x25519-dalek`: 1.1 -> 2.0.1, `age`: 0.9 -> 0.10).

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -7,7 +7,7 @@ mkdir coverage
 
 # Run tests with profiling instrumentation
 echo "Running instrumented unit tests..."
-RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="crypto-rs-%m.profraw" cargo +nightly test --tests --all --all-features
+RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="crypto-rs-%m.profraw" cargo +nightly test --tests --all --all-features
 
 # Merge all .profraw files into "crypto-rs.profdata"
 echo "Merging coverage data..."
@@ -19,7 +19,7 @@ BINARIES=""
 
 for file in \
   $( \
-    RUSTFLAGS="-Zinstrument-coverage" \
+    RUSTFLAGS="-Cinstrument-coverage" \
       cargo +nightly test --tests --all --all-features --no-run --message-format=json \
         | jq -r "select(.profile.test == true) | .filenames[]" \
         | grep -v dSYM - \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,6 @@ age = { version = "0.10", default-features = false }
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_i128)', 'cfg(has_u128)'] }


### PR DESCRIPTION
# Description of change

This PR updates the code `instrument-coverage` flag to be set as a stable option, as this option has moved from unstable to stable.

Updated clippy found unexpected cfgs `has_i128` and `has_u128`. As those are set in the `build.rs`, linting rule has been configured in `Cargo.toml` to allow the known two cfgs. 

It also adds a changelog entry for the previous (#223).

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Chore

## How the change has been tested

Code coverage command from CI ran successfully in local tests.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes